### PR TITLE
Fix for not detecting GuestAdditions running in Centos 6.

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -78,7 +78,7 @@ module VagrantVbguest
         opts = {
           :sudo => true
         }.merge(opts || {})
-        communicate.test('grep -qE "^vboxguest\s.+\s\([^\s]*O[^\s]*\)$" /proc/modules && ls /lib/modules/`uname -r`/misc/vboxsf.ko*', opts, &block)
+        communicate.test('grep -qE "^vboxguest\s.+\s" /proc/modules && ls /lib/modules/`uname -r`/misc/vboxsf.ko*', opts, &block)
       end
 
       # This overrides {VagrantVbguest::Installers::Base#guest_version}


### PR DESCRIPTION
This fixes the same issue that has been reported a number of times since #334 was merged.

#347
#376

